### PR TITLE
Fix integer overflow

### DIFF
--- a/src/main/java/com/mrdimka/solarfluxreborn/init/FusionRecipes.java
+++ b/src/main/java/com/mrdimka/solarfluxreborn/init/FusionRecipes.java
@@ -13,6 +13,6 @@ public class FusionRecipes
 	public static void register()
 	{
 		if(DraconicEvolutionConfigs.chaoticSolar && DraconicEvolutionConfigs.draconicSolar && DraconicEvolutionConfigs.useFusionForChaotic)
-		FusionRecipeAPI.addRecipe(new SimpleFusionRecipe(new ItemStack(ModBlocks.chaoticSolar, 3), new ItemStack(Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "chaos_shard"))), 1000000000, 3, ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core")), ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core")), ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core")), ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core"))));
+		FusionRecipeAPI.addRecipe(new SimpleFusionRecipe(new ItemStack(ModBlocks.chaoticSolar, 3), new ItemStack(Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "chaos_shard"))), 128000000, 3, ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core")), ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core")), ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core")), ModBlocks.draconicSolar, Item.REGISTRY.getObject(new ResourceLocation("draconicevolution", "awakened_core"))));
 	}
 }


### PR DESCRIPTION
The energyCost parameter of the SimpleFusionRecipe constructor is multiplied by the number of pedestals used. A cost of 1,000,000,000 will cause an integer overflow since the total cost is stored as signed 32bit integer. If the total crafting cost was supposed to be 1bn RF, 128,000,000 would be the correct amount in the function call. Alternatively change the amount to 256m to match the most expensive chaotic recipe in DE with 2bn RF.